### PR TITLE
Lab08 filesystems

### DIFF
--- a/Documentation/teaching/labs/filesystems_part2.rst
+++ b/Documentation/teaching/labs/filesystems_part2.rst
@@ -477,7 +477,7 @@ In the minix case, the function is ``minix_lookup``.
 This function is called indirectly when information about the inode associated with an entry in a directory is needed.
 Such a function performs the following operations:
 
-  #. Searces in the directory indicated by ``dir`` the entry having the name ``dentry->d_name.name``.
+  #. Searches in the directory indicated by ``dir`` the entry having the name ``dentry->d_name.name``.
   #. If the entry is found, it will return ``NULL`` and associate the inode with the name using the :c:func:`d_add` function.
   #. Otherwise, returns ``ERR_PTR``.
 

--- a/Documentation/teaching/so2/assign-collaboration.rst
+++ b/Documentation/teaching/so2/assign-collaboration.rst
@@ -1,0 +1,144 @@
+=============
+Collaboration
+=============
+
+Collaboration is essential in open source world and we encourage you
+to pick a team partner to work on selected assignments.
+
+Here is a simple guide to get you started:
+
+1. Use Github / Gitlab
+----------------------
+
+Best way to share your work inside the team is to use a version control system (VCS)
+in order to track each change. Mind that you must make your repo private and only allow
+read/write access rights to team members.
+
+2. Start with a skeleton for the assignment
+-------------------------------------------
+
+Add `init`/`exit` functions, driver operations and global structures that you driver might need.
+
+.. code-block:: c
+
+  // SPDX-License-Identifier: GPL-2.0
+  /*
+   * uart16550.c - UART16550 driver
+   *
+   * Author: John Doe <john.doe@mail.com>
+   * Author: Ionut Popescu <ionut.popescu@mail.com>
+   */
+  struct uart16550_dev {
+     struct cdev cdev;
+     /*TODO */
+  };
+
+  static struct uart16550_dev devs[MAX_NUMBER_DEVICES];
+
+  static int uart16550_open(struct inode *inode, struct file *file)
+  {
+      /*TODO */
+      return 0;
+  }
+
+  static int uart16550_release(struct inode *inode, struct file *file)
+  {
+     /*TODO */
+     return 0;
+  }
+
+  static ssize_t uart16550_read(struct file *file,  char __user *user_buffer,
+                                size_t size, loff_t *offset)
+  {
+        /*TODO */
+  }
+
+  static ssize_t uart16550_write(struct file *file,
+                                 const char __user *user_buffer,
+                                 size_t size, loff_t *offset)
+  {
+       /*TODO */
+  }
+
+  static long
+  uart16550_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
+  {
+        /*TODO */
+        return 0;
+  }
+
+  static const struct file_operations uart16550_fops = {
+         .owner		 = THIS_MODULE,
+         .open		 = uart16550_open,
+         .release	 = uart16550_release,
+         .read		 = uart16550_read,
+         .write		 = uart16550_write,
+         .unlocked_ioctl = uart16550_ioctl
+  };
+
+  static int __init uart16550_init(void)
+  {
+    /* TODO: */
+  }
+
+  static void __exit uart16550_exit(void)
+  {
+     /* TODO: */
+  }
+
+  module_init(uart16550_init);
+  module_exit(uart16550_exit);
+
+  MODULE_DESCRIPTION("UART16550 Driver");
+  MODULE_AUTHOR("John Doe <john.doe@mail.com");
+  MODULE_AUTHOR("Ionut Popescu <ionut.popescu@mail.com");
+
+3. Add a commit for each individual change
+------------------------------------------
+
+First commit must always be the skeleton file. And the rest of the code should be on top of skeleton file.
+Please write a good commit mesage. Explain briefly what the commit does and *why* it is necessary.
+
+Follow the seven rules of writing a good commit message: https://cbea.ms/git-commit/#seven-rules
+
+.. code-block:: console
+
+  Commit 3c92a02cc52700d2cd7c50a20297eef8553c207a (HEAD -> tema2)
+  Author: John Doe <john.doe@mail.com>
+  Date:   Mon Apr 4 11:54:39 2022 +0300
+
+    uart16550: Add initial skeleton for ssignment #2
+
+    This adds simple skeleton file for uart16550 assignment. Notice
+    module init/exit callbacks and file_operations dummy implementation
+    for open/release/read/write/ioctl.
+
+    Signed-off-by: John Doe <john.doe@mail.com>
+
+4. Split the work inside the team
+---------------------------------
+
+Add `TODOs` with each team member tasks. Try to split the work evenly.
+
+Before starting to code, make a plan. On top of your skeleton file, add TODOs with each member tasks. Agree on global
+structures and the overlall driver design. Then start coding.
+
+5. Do reviews
+-------------
+
+Create Pull Requests with your commits and go through review rounds with your team members. You can follow `How to create a PR` `video <https://www.youtube.com/watch?v=YvoHJJWvn98>`_.
+
+6. Merge the work
+-----------------
+
+The final work is the result of merging all the pull requests. Following the commit messages
+one should clearly understand the progress of the code and how the work was managed inside the team.
+
+.. code-block:: console
+
+  f5118b873294 uart16550: Add uart16550_interrupt implementation
+  2115503fc3e3 uart16550: Add uart16550_ioctl implementation
+  b31a257fd8b8 uart16550: Add uart16550_write implementation
+  ac1af6d88a25 uart16550: Add uart16550_read implementation
+  9f680e8136bf uart16550: Add uart16550_open/release implementation
+  3c92a02cc527 uart16550: Add skeleton for SO2 assignment #2

--- a/Documentation/teaching/so2/index.rst
+++ b/Documentation/teaching/so2/index.rst
@@ -41,6 +41,7 @@ Operating Systems 2
    :caption: Assignments
    :maxdepth: 1
 
+   assign-collaboration.rst
    assign0-kernel-api.rst
    assign1-kprobe-based-tracer.rst
    assign2-driver-uart.rst

--- a/tools/labs/skels/filesystems/minfs/kernel/Kbuild
+++ b/tools/labs/skels/filesystems/minfs/kernel/Kbuild
@@ -1,0 +1,3 @@
+EXTRA_CFLAGS = -Wall -g -Wno-unused
+
+obj-m = minfs.o

--- a/tools/labs/skels/filesystems/minfs/kernel/minfs.c
+++ b/tools/labs/skels/filesystems/minfs/kernel/minfs.c
@@ -1,0 +1,512 @@
+/*
+ * SO2 Lab - Filesystem drivers
+ * Exercise #2 (dev filesystem)
+ */
+
+#include <linux/buffer_head.h>
+#include <linux/cred.h>
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/pagemap.h>
+#include <linux/sched.h>
+#include <linux/slab.h>
+
+#include "minfs.h"
+
+MODULE_DESCRIPTION("Simple filesystem");
+MODULE_AUTHOR("SO2");
+MODULE_LICENSE("GPL");
+
+#define LOG_LEVEL	KERN_ALERT
+
+
+struct minfs_sb_info {
+	__u8 version;
+	unsigned long imap;
+	struct buffer_head *sbh;
+};
+
+struct minfs_inode_info {
+	__u16 data_block;
+	struct inode vfs_inode;
+};
+
+/* declarations of functions that are part of operation structures */
+
+static int minfs_readdir(struct file *filp, struct dir_context *ctx);
+static struct dentry *minfs_lookup(struct inode *dir,
+		struct dentry *dentry, unsigned int flags);
+static int minfs_create(struct inode *dir, struct dentry *dentry,
+		umode_t mode, bool excl);
+
+/* dir and inode operation structures */
+
+static const struct file_operations minfs_dir_operations = {
+	.read		= generic_read_dir,
+	.iterate	= minfs_readdir,
+};
+
+static const struct inode_operations minfs_dir_inode_operations = {
+	.lookup		= minfs_lookup,
+	/* TODO 7: Use minfs_create as the create function. */
+};
+
+static const struct address_space_operations minfs_aops = {
+	.readpage       = simple_readpage,
+	.write_begin    = simple_write_begin,
+	.write_end      = simple_write_end,
+};
+
+static const struct file_operations minfs_file_operations = {
+	.read_iter	= generic_file_read_iter,
+	.write_iter	= generic_file_write_iter,
+	.mmap		= generic_file_mmap,
+	.llseek		= generic_file_llseek,
+};
+
+static const struct inode_operations minfs_file_inode_operations = {
+	.getattr	= simple_getattr,
+};
+
+static struct inode *minfs_iget(struct super_block *s, unsigned long ino)
+{
+	struct minfs_inode *mi;
+	struct buffer_head *bh;
+	struct inode *inode;
+	struct minfs_inode_info *mii;
+
+	/* Allocate VFS inode. */
+	inode = iget_locked(s, ino);
+	if (inode == NULL) {
+		printk(LOG_LEVEL "error aquiring inode\n");
+		return ERR_PTR(-ENOMEM);
+	}
+
+	/* Return inode from cache */
+	if (!(inode->i_state & I_NEW))
+		return inode;
+
+	/* TODO 4: Read block with inodes. It's the second block on
+	 * the device, i.e. the block with the index 1. This is the index
+	 * to be passed to sb_bread().
+	 */
+
+	/* TODO 4: Get inode with index ino from the block. */
+
+	/* TODO 4: fill VFS inode */
+
+	/* TODO 7: Fill address space operations (inode->i_mapping->a_ops) */
+
+	if (S_ISDIR(inode->i_mode)) {
+		/* TODO 4: Fill dir inode operations. */
+
+		/* TODO 5: Use minfs_dir_inode_operations for i_op
+		 * and minfs_dir_operations for i_fop. */
+
+		/* TODO 4: Directory inodes start off with i_nlink == 2.
+		 * (use inc_link) */
+	}
+
+	/* TODO 7: Fill inode and file operations for regular files
+	 * (i_op and i_fop). Use the S_ISREG macro.
+	 */
+
+	/* fill data for mii */
+	mii = container_of(inode, struct minfs_inode_info, vfs_inode);
+
+	/* TODO 4: uncomment after the minfs_inode is initialized */
+	//mii->data_block = mi->data_block;
+
+	/* Free resources. */
+	/* TODO 4: uncomment after the buffer_head is initialized */
+	//brelse(bh);
+	unlock_new_inode(inode);
+
+	return inode;
+
+out_bad_sb:
+	iget_failed(inode);
+	return NULL;
+}
+
+static int minfs_readdir(struct file *filp, struct dir_context *ctx)
+{
+	struct buffer_head *bh;
+	struct minfs_dir_entry *de;
+	struct minfs_inode_info *mii;
+	struct inode *inode;
+	struct super_block *sb;
+	int over;
+	int err = 0;
+
+	/* TODO 5: Get inode of directory and container inode. */
+
+	/* TODO 5: Get superblock from inode (i_sb). */
+
+	/* TODO 5: Read data block for directory inode. */
+
+	for (; ctx->pos < MINFS_NUM_ENTRIES; ctx->pos++) {
+		/* TODO 5: Data block contains an array of
+		 * "struct minfs_dir_entry". Use `de' for storing.
+		 */
+
+		/* TODO 5: Step over empty entries (de->ino == 0). */
+
+		/*
+		 * Use `over` to store return value of dir_emit and exit
+		 * if required.
+		 */
+		over = dir_emit(ctx, de->name, MINFS_NAME_LEN, de->ino,
+				DT_UNKNOWN);
+		if (over) {
+			printk(KERN_DEBUG "Read %s from folder %s, ctx->pos: %lld\n",
+				de->name,
+				filp->f_path.dentry->d_name.name,
+				ctx->pos);
+			ctx->pos++;
+			goto done;
+		}
+	}
+
+done:
+	brelse(bh);
+out_bad_sb:
+	return err;
+}
+
+/*
+ * Find dentry in parent folder. Return parent folder's data buffer_head.
+ */
+
+static struct minfs_dir_entry *minfs_find_entry(struct dentry *dentry,
+		struct buffer_head **bhp)
+{
+	struct buffer_head *bh;
+	struct inode *dir = dentry->d_parent->d_inode;
+	struct minfs_inode_info *mii = container_of(dir,
+			struct minfs_inode_info, vfs_inode);
+	struct super_block *sb = dir->i_sb;
+	const char *name = dentry->d_name.name;
+	struct minfs_dir_entry *final_de = NULL;
+	struct minfs_dir_entry *de;
+	int i;
+
+	/* TODO 6: Read parent folder data block (contains dentries).
+	 * Fill bhp with return value.
+	 */
+
+	for (i = 0; i < MINFS_NUM_ENTRIES; i++) {
+		/* TODO 6: Traverse all entries, find entry by name
+		 * Use `de' to traverse. Use `final_de' to store dentry
+		 * found, if existing.
+		 */
+	}
+
+	/* bh needs to be released by caller. */
+	return final_de;
+}
+
+static struct dentry *minfs_lookup(struct inode *dir,
+		struct dentry *dentry, unsigned int flags)
+{
+	/* TODO 6: Comment line. */
+	return simple_lookup(dir, dentry, flags);
+
+	struct super_block *sb = dir->i_sb;
+	struct minfs_dir_entry *de;
+	struct buffer_head *bh = NULL;
+	struct inode *inode = NULL;
+
+	dentry->d_op = sb->s_root->d_op;
+
+	de = minfs_find_entry(dentry, &bh);
+	if (de != NULL) {
+		printk(KERN_DEBUG "getting entry: name: %s, ino: %d\n",
+			de->name, de->ino);
+		inode = minfs_iget(sb, de->ino);
+		if (IS_ERR(inode))
+			return ERR_CAST(inode);
+	}
+
+	d_add(dentry, inode);
+	brelse(bh);
+
+	printk(KERN_DEBUG "looked up dentry %s\n", dentry->d_name.name);
+
+	return NULL;
+}
+
+static struct inode *minfs_alloc_inode(struct super_block *s)
+{
+	struct minfs_inode_info *mii;
+
+	/* TODO 3: Allocate minfs_inode_info. */
+	/* TODO 3: init VFS inode in minfs_inode_info */
+
+	return &mii->vfs_inode;
+}
+
+static void minfs_destroy_inode(struct inode *inode)
+{
+	/* TODO 3: free minfs_inode_info */
+}
+
+/*
+ * Create a new VFS inode. Do basic initialization and fill imap.
+ */
+
+static struct inode *minfs_new_inode(struct inode *dir)
+{
+	struct super_block *sb = dir->i_sb;
+	struct minfs_sb_info *sbi = sb->s_fs_info;
+	struct inode *inode;
+	int idx;
+
+	/* TODO 7: Find first available inode. */
+
+	/* TODO 7: Mark the inode as used in the bitmap and mark
+	 * the superblock buffer head as dirty.
+	 */
+
+	/* TODO 7: Call new_inode(), fill inode fields
+	 * and insert inode into inode hash table.
+	 */
+
+	/* Actual writing to the disk will be done in minfs_write_inode,
+	 * which will be called at a later time.
+	 */
+
+	return inode;
+}
+
+/*
+ * Add dentry link on parent inode disk structure.
+ */
+
+static int minfs_add_link(struct dentry *dentry, struct inode *inode)
+{
+	struct buffer_head *bh;
+	struct inode *dir;
+	struct super_block *sb;
+	struct minfs_inode_info *mii;
+	struct minfs_dir_entry *de;
+	int i;
+	int err = 0;
+
+	/* TODO 7: Get: directory inode (in inode); containing inode (in mii); superblock (in sb). */
+
+	/* TODO 7: Read dir data block (use sb_bread). */
+
+	/* TODO 7: Find first free dentry (de->ino == 0). */
+
+	/* TODO 7: Place new entry in the available slot. Mark buffer_head
+	 * as dirty. */
+
+out:
+	brelse(bh);
+
+	return err;
+}
+
+/*
+ * Create a VFS file inode. Use minfs_file_... operations.
+ */
+
+static int minfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
+		bool excl)
+{
+	struct inode *inode;
+	struct minfs_inode_info *mii;
+	int err;
+
+	inode = minfs_new_inode(dir);
+	if (inode == NULL) {
+		printk(LOG_LEVEL "error allocating new inode\n");
+		err = -ENOMEM;
+		goto err_new_inode;
+	}
+
+	inode->i_mode = mode;
+	inode->i_op = &minfs_file_inode_operations;
+	inode->i_fop = &minfs_file_operations;
+	mii = container_of(inode, struct minfs_inode_info, vfs_inode);
+	mii->data_block = MINFS_FIRST_DATA_BLOCK + inode->i_ino;
+
+	err = minfs_add_link(dentry, inode);
+	if (err != 0)
+		goto err_add_link;
+
+	d_instantiate(dentry, inode);
+	mark_inode_dirty(inode);
+
+	printk(KERN_DEBUG "new file inode created (ino = %lu)\n",
+		inode->i_ino);
+
+	return 0;
+
+err_add_link:
+	inode_dec_link_count(inode);
+	iput(inode);
+err_new_inode:
+	return err;
+}
+
+/*
+ * Write VFS inode contents to disk inode.
+ */
+
+static int minfs_write_inode(struct inode *inode,
+		struct writeback_control *wbc)
+{
+	struct super_block *sb = inode->i_sb;
+	struct minfs_inode *mi;
+	struct minfs_inode_info *mii = container_of(inode,
+			struct minfs_inode_info, vfs_inode);
+	struct buffer_head *bh;
+	int err = 0;
+
+	bh = sb_bread(sb, MINFS_INODE_BLOCK);
+	if (bh == NULL) {
+		printk(LOG_LEVEL "could not read block\n");
+		err = -ENOMEM;
+		goto out;
+	}
+
+	mi = (struct minfs_inode *) bh->b_data + inode->i_ino;
+
+	/* fill disk inode */
+	mi->mode = inode->i_mode;
+	mi->uid = i_uid_read(inode);
+	mi->gid = i_gid_read(inode);
+	mi->size = inode->i_size;
+	mi->data_block = mii->data_block;
+
+	printk(KERN_DEBUG "mode is %05o; data_block is %d\n", mi->mode,
+		mii->data_block);
+
+	mark_buffer_dirty(bh);
+	brelse(bh);
+
+	printk(KERN_DEBUG "wrote inode %lu\n", inode->i_ino);
+
+out:
+	return err;
+}
+
+static void minfs_put_super(struct super_block *sb)
+{
+	struct minfs_sb_info *sbi = sb->s_fs_info;
+
+	/* Free superblock buffer head. */
+	mark_buffer_dirty(sbi->sbh);
+	brelse(sbi->sbh);
+
+	printk(KERN_DEBUG "released superblock resources\n");
+}
+
+static const struct super_operations minfs_ops = {
+	.statfs		= simple_statfs,
+	.put_super	= minfs_put_super,
+	/* TODO 4: add alloc and destroy inode functions */
+	/* TODO 7:	= set write_inode function. */
+};
+
+static int minfs_fill_super(struct super_block *s, void *data, int silent)
+{
+	struct minfs_sb_info *sbi;
+	struct minfs_super_block *ms;
+	struct inode *root_inode;
+	struct dentry *root_dentry;
+	struct buffer_head *bh;
+	int ret = -EINVAL;
+
+	sbi = kzalloc(sizeof(struct minfs_sb_info), GFP_KERNEL);
+	if (!sbi)
+		return -ENOMEM;
+	s->s_fs_info = sbi;
+
+	/* Set block size for superblock. */
+	if (!sb_set_blocksize(s, MINFS_BLOCK_SIZE))
+		goto out_bad_blocksize;
+
+	/* TODO 2: Read block with superblock. It's the first block on
+	 * the device, i.e. the block with the index 0. This is the index
+	 * to be passed to sb_bread().
+	 */
+
+	/* TODO 2: interpret read data as minfs_super_block */
+
+	/* TODO 2: check magic number with value defined in minfs.h. jump to out_bad_magic if not suitable */
+
+	/* TODO 2: fill super_block with magic_number, super_operations */
+
+	/* TODO 2: Fill sbi with rest of information from disk superblock
+	 * (i.e. version).
+	 */
+
+	/* allocate root inode and root dentry */
+	/* TODO 2: use myfs_get_inode instead of minfs_iget */
+	root_inode = minfs_iget(s, MINFS_ROOT_INODE);
+	if (!root_inode)
+		goto out_bad_inode;
+
+	root_dentry = d_make_root(root_inode);
+	if (!root_dentry)
+		goto out_iput;
+	s->s_root = root_dentry;
+
+	/* Store superblock buffer_head for further use. */
+	sbi->sbh = bh;
+
+	return 0;
+
+out_iput:
+	iput(root_inode);
+out_bad_inode:
+	printk(LOG_LEVEL "bad inode\n");
+out_bad_magic:
+	printk(LOG_LEVEL "bad magic number\n");
+	brelse(bh);
+out_bad_sb:
+	printk(LOG_LEVEL "error reading buffer_head\n");
+out_bad_blocksize:
+	printk(LOG_LEVEL "bad block size\n");
+	s->s_fs_info = NULL;
+	kfree(sbi);
+	return ret;
+}
+
+static struct dentry *minfs_mount(struct file_system_type *fs_type,
+		int flags, const char *dev_name, void *data)
+{
+	/* TODO 1: call superblock mount function */
+}
+
+static struct file_system_type minfs_fs_type = {
+	.owner		= THIS_MODULE,
+	.name		= "minfs",
+	/* TODO 1: add mount, kill_sb and fs_flags */
+};
+
+static int __init minfs_init(void)
+{
+	int err;
+
+	err = register_filesystem(&minfs_fs_type);
+	if (err) {
+		printk(LOG_LEVEL "register_filesystem failed\n");
+		return err;
+	}
+
+	return 0;
+}
+
+static void __exit minfs_exit(void)
+{
+	unregister_filesystem(&minfs_fs_type);
+}
+
+module_init(minfs_init);
+module_exit(minfs_exit);

--- a/tools/labs/skels/filesystems/minfs/kernel/minfs.h
+++ b/tools/labs/skels/filesystems/minfs/kernel/minfs.h
@@ -1,0 +1,45 @@
+#ifndef _MINFS_H
+#define _MINFS_H	1
+
+#define MINFS_MAGIC		0xDEADF00D
+#define MINFS_NAME_LEN		16
+#define MINFS_BLOCK_SIZE	4096
+#define MINFS_NUM_INODES	32
+#define MINFS_NUM_ENTRIES	32
+
+#define MINFS_ROOT_INODE	0
+
+/*
+ * Filesystem layout:
+ *
+ *      SB      IZONE 	     DATA
+ *    ^	    ^ (1 block)
+ *    |     |
+ *    +-0   +-- 4096
+ */
+
+#define MINFS_SUPER_BLOCK	0
+#define MINFS_INODE_BLOCK	1
+#define MINFS_FIRST_DATA_BLOCK	2
+
+struct minfs_super_block {
+	unsigned long magic;
+	__u8 version;
+	unsigned long imap;
+};
+
+struct minfs_dir_entry {
+	__u32 ino;
+	char name[MINFS_NAME_LEN];
+};
+
+/* A minfs inode uses a single block. */
+struct minfs_inode {
+	__u32 mode;
+	__u32 uid;
+	__u32 gid;
+	__u32 size;
+	__u16 data_block;
+};
+
+#endif /* _MINFS_H */

--- a/tools/labs/skels/filesystems/minfs/user/.gitignore
+++ b/tools/labs/skels/filesystems/minfs/user/.gitignore
@@ -1,0 +1,1 @@
+/mkfs.minfs

--- a/tools/labs/skels/filesystems/minfs/user/Makefile
+++ b/tools/labs/skels/filesystems/minfs/user/Makefile
@@ -1,0 +1,13 @@
+CFLAGS = -Wall -g -m32
+LDFLAGS = -static -m32
+
+.PHONY: all clean
+
+all: mkfs.minfs
+
+mkfs.minfs: mkfs.minfs.o
+
+mkfs.minfs.o: mkfs.minfs.c ../kernel/minfs.h
+
+clean:
+	-rm -f *~ *.o mkfs.minfs

--- a/tools/labs/skels/filesystems/minfs/user/mkfs.minfs.c
+++ b/tools/labs/skels/filesystems/minfs/user/mkfs.minfs.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/stat.h>
+#include <linux/types.h>
+
+#include "../kernel/minfs.h"
+
+/*
+ * mk_minfs file
+ */
+
+int main(int argc, char **argv)
+{
+	FILE *file;
+	char buffer[MINFS_BLOCK_SIZE];
+	struct minfs_super_block msb;
+	struct minfs_inode root_inode;
+	struct minfs_inode file_inode;
+	struct minfs_dir_entry file_dentry;
+	int i;
+
+	if (argc != 2) {
+		fprintf(stderr, "Usage: %s block_device_name\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	file = fopen(argv[1], "w+");
+	if (file == NULL) {
+		perror("fopen");
+		exit(EXIT_FAILURE);
+	}
+
+	memset(&msb, 0, sizeof(struct minfs_super_block));
+
+	msb.magic = MINFS_MAGIC;
+	msb.version = 1;
+	msb.imap = 0x03;
+
+	/* zero disk  */
+	memset(buffer, 0,  MINFS_BLOCK_SIZE);
+	for (i = 0; i < 128; i++)
+		fwrite(buffer, 1, MINFS_BLOCK_SIZE, file);
+
+	fseek(file, 0, SEEK_SET);
+
+	/* initialize super block */
+	fwrite(&msb, sizeof(msb), 1, file);
+
+	/* initialize root inode */
+	memset(&root_inode, 0, sizeof(root_inode));
+	root_inode.uid = 0;
+	root_inode.gid = 0;
+	root_inode.mode = S_IFDIR | 0755;
+	root_inode.size = 0;
+	root_inode.data_block = MINFS_FIRST_DATA_BLOCK;
+
+	fseek(file, MINFS_INODE_BLOCK * MINFS_BLOCK_SIZE, SEEK_SET);
+	fwrite(&root_inode, sizeof(root_inode), 1, file);
+
+	/* initialize new inode */
+	memset(&file_inode, 0, sizeof(file_inode));
+	file_inode.uid = 0;
+	file_inode.gid = 0;
+	file_inode.mode = S_IFREG | 0644;
+	file_inode.size = 0;
+	file_inode.data_block = MINFS_FIRST_DATA_BLOCK + 1;
+	fwrite(&file_inode, sizeof(file_inode), 1, file);
+
+	/* add dentry information */
+	memset(&file_dentry, 0, sizeof(file_dentry));
+	file_dentry.ino = 1;
+	memcpy(file_dentry.name, "a.txt", 5);
+	fseek(file, MINFS_FIRST_DATA_BLOCK * MINFS_BLOCK_SIZE, SEEK_SET);
+	fwrite(&file_dentry, sizeof(file_dentry), 1, file);
+
+	fclose(file);
+
+	return 0;
+}

--- a/tools/labs/skels/filesystems/minfs/user/test-minfs-0.sh
+++ b/tools/labs/skels/filesystems/minfs/user/test-minfs-0.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# load module
+insmod ../kernel/minfs.ko
+
+# create mount point
+mkdir -p /mnt/minfs
+
+# format partition
+./mkfs.minfs /dev/vdb
+
+# mount filesystem
+mount -t minfs /dev/vdb /mnt/minfs
+
+# show registered filesystems
+cat /proc/filesystems
+
+# show mounted filesystems
+cat /proc/mounts
+
+# umount filesystem
+umount /mnt/minfs
+
+# unload module
+rmmod minfs

--- a/tools/labs/skels/filesystems/minfs/user/test-minfs-1.sh
+++ b/tools/labs/skels/filesystems/minfs/user/test-minfs-1.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# load module
+insmod ../kernel/minfs.ko
+
+# create mount point
+mkdir -p /mnt/minfs
+
+# format partition
+./mkfs.minfs /dev/vdb
+
+# mount filesystem
+mount -t minfs /dev/vdb /mnt/minfs
+
+# list all filesystem files
+cd /mnt/minfs
+ls -la
+
+# unmount filesystem
+cd ..
+umount /mnt/minfs
+
+# unload module
+rmmod minfs

--- a/tools/labs/skels/filesystems/minfs/user/test-minfs-2.sh
+++ b/tools/labs/skels/filesystems/minfs/user/test-minfs-2.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+pushd . > /dev/null 2>&1
+
+# load module
+insmod ../kernel/minfs.ko
+
+# create mount point
+mkdir -p /mnt/minfs
+
+# format partition
+./mkfs.minfs /dev/vdb
+
+# mount filesystem
+mount -t minfs /dev/vdb /mnt/minfs
+
+# change to minfs root folder
+cd /mnt/minfs
+
+# create new file
+touch b.txt && echo "OK. File created." || echo "NOT OK. File creation failed."
+
+# unmount filesystem
+cd ..
+umount /mnt/minfs
+
+popd > /dev/null 2>&1
+
+# mount filesystem
+mount -t minfs /dev/vdb /mnt/minfs
+
+# check whether b.txt is still there
+ls /mnt/minfs | grep b.txt && echo "OK. File b.txt exists " || echo "NOT OK. File b.txt does not exist."
+
+# unmount filesystem
+umount /mnt/minfs
+
+# unload module
+rmmod minfs

--- a/tools/labs/skels/filesystems/minfs/user/test-minfs.sh
+++ b/tools/labs/skels/filesystems/minfs/user/test-minfs.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -ex
+
+#load module
+insmod ../kernel/minfs.ko
+
+#create mount point
+mkdir -p /mnt/minfs
+
+#format partition
+./mkfs.minfs /dev/vdb
+
+#mount filesystem
+mount -t minfs /dev/vdb /mnt/minfs
+
+#show registered filesystems
+cat /proc/filesystems | grep minfs
+
+#show mounted filesystems
+cat /proc/mounts | grep minfs
+
+#show filesystem statistics
+stat -f /mnt/minfs
+
+#list all filesystem files
+cd /mnt/minfs
+ls -la
+
+#unmount filesystem
+cd ..
+umount /mnt/minfs
+
+#unload module
+rmmod minfs

--- a/tools/labs/skels/filesystems/myfs/Kbuild
+++ b/tools/labs/skels/filesystems/myfs/Kbuild
@@ -1,0 +1,3 @@
+EXTRA_CFLAGS = -Wall -g -Wno-unused
+
+obj-m = myfs.o

--- a/tools/labs/skels/filesystems/myfs/myfs.c
+++ b/tools/labs/skels/filesystems/myfs/myfs.c
@@ -1,0 +1,149 @@
+/*
+ * SO2 Lab - Filesystem drivers
+ * Exercise #1 (no-dev filesystem)
+ */
+
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/fs.h>
+#include <linux/pagemap.h>
+
+MODULE_DESCRIPTION("Simple no-dev filesystem");
+MODULE_AUTHOR("SO2");
+MODULE_LICENSE("GPL");
+
+#define MYFS_BLOCKSIZE		4096
+#define MYFS_BLOCKSIZE_BITS	12
+#define MYFS_MAGIC		0xbeefcafe
+#define LOG_LEVEL		KERN_ALERT
+
+/* declarations of functions that are part of operation structures */
+
+static int myfs_mknod(struct inode *dir,
+		struct dentry *dentry, umode_t mode, dev_t dev);
+static int myfs_create(struct inode *dir, struct dentry *dentry,
+		umode_t mode, bool excl);
+static int myfs_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode);
+
+/* TODO 2: define super_operations structure */
+
+static const struct inode_operations myfs_dir_inode_operations = {
+	/* TODO 5: Fill dir inode operations structure. */
+};
+
+static const struct file_operations myfs_file_operations = {
+	/* TODO 6: Fill file operations structure. */
+};
+
+static const struct inode_operations myfs_file_inode_operations = {
+	/* TODO 6: Fill file inode operations structure. */
+};
+
+static const struct address_space_operations myfs_aops = {
+	/* TODO 6: Fill address space operations structure. */
+};
+
+struct inode *myfs_get_inode(struct super_block *sb, const struct inode *dir,
+		int mode)
+{
+	struct inode *inode = new_inode(sb);
+
+	if (!inode)
+		return NULL;
+
+	/* TODO 3: fill inode structure
+	 *     - mode
+	 *     - uid
+	 *     - gid
+	 *     - atime,ctime,mtime
+	 *     - ino
+	 */
+
+	/* TODO 5: Init i_ino using get_next_ino */
+
+	/* TODO 6: Initialize address space operations. */
+
+	if (S_ISDIR(mode)) {
+		/* TODO 3: set inode operations for dir inodes. */
+
+		/* TODO 5: use myfs_dir_inode_operations for inode
+		 * operations (i_op).
+		 */
+
+		/* TODO 3: directory inodes start off with i_nlink == 2 (for "." entry).
+		 * Directory link count should be incremented (use inc_nlink).
+		 */
+	}
+
+	/* TODO 6: Set file inode and file operations for regular files
+	 * (use the S_ISREG macro).
+	 */
+
+	return inode;
+}
+
+/* TODO 5: Implement myfs_mknod, myfs_create, myfs_mkdir. */
+
+static int myfs_fill_super(struct super_block *sb, void *data, int silent)
+{
+	struct inode *root_inode;
+	struct dentry *root_dentry;
+
+	/* TODO 2: fill super_block
+	 *   - blocksize, blocksize_bits
+	 *   - magic
+	 *   - super operations
+	 *   - maxbytes
+	 */
+
+	/* mode = directory & access rights (755) */
+	root_inode = myfs_get_inode(sb, NULL,
+			S_IFDIR | S_IRWXU | S_IRGRP |
+			S_IXGRP | S_IROTH | S_IXOTH);
+
+	printk(LOG_LEVEL "root inode has %d link(s)\n", root_inode->i_nlink);
+
+	if (!root_inode)
+		return -ENOMEM;
+
+	root_dentry = d_make_root(root_inode);
+	if (!root_dentry)
+		goto out_no_root;
+	sb->s_root = root_dentry;
+
+	return 0;
+
+out_no_root:
+	iput(root_inode);
+	return -ENOMEM;
+}
+
+static struct dentry *myfs_mount(struct file_system_type *fs_type,
+		int flags, const char *dev_name, void *data)
+{
+	/* TODO 1: call superblock mount function */
+}
+
+/* TODO 1: define file_system_type structure */
+
+static int __init myfs_init(void)
+{
+	int err;
+
+	/* TODO 1: register */
+	if (err) {
+		printk(LOG_LEVEL "register_filesystem failed\n");
+		return err;
+	}
+
+	return 0;
+}
+
+static void __exit myfs_exit(void)
+{
+	/* TODO 1: unregister */
+}
+
+module_init(myfs_init);
+module_exit(myfs_exit);

--- a/tools/labs/skels/filesystems/myfs/test-myfs-1.sh
+++ b/tools/labs/skels/filesystems/myfs/test-myfs-1.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -x
+
+# load module
+insmod myfs.ko
+
+# mount filesystem
+mkdir -p /mnt/myfs
+mount -t myfs none /mnt/myfs
+ls -laid /mnt/myfs
+
+cd /mnt/myfs
+
+# create directory
+mkdir mydir
+ls -la
+
+# create subdirectory
+cd mydir
+mkdir mysubdir
+ls -lai
+
+# rename subdirectory
+mv mysubdir myrenamedsubdir
+ls -lai
+
+# delete renamed subdirectory
+rmdir myrenamedsubdir
+ls -la
+
+# create file
+touch myfile
+ls -lai
+
+# rename file
+mv myfile myrenamedfile
+ls -lai
+
+# delete renamed file
+rm myrenamedfile
+
+# delete directory
+cd ..
+rmdir mydir
+ls -la
+
+# unmount filesystem
+cd ..
+umount /mnt/myfs
+
+# unload module
+rmmod myfs

--- a/tools/labs/skels/filesystems/myfs/test-myfs-2.sh
+++ b/tools/labs/skels/filesystems/myfs/test-myfs-2.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -ex
+
+# load module
+insmod myfs.ko
+
+# mount filesystem
+mkdir -p /mnt/myfs
+mount -t myfs none /mnt/myfs
+ls -laid /mnt/myfs
+
+cd /mnt/myfs
+
+# create file
+touch myfile
+ls -lai
+
+# rename file
+mv myfile myrenamedfile
+ls -lai
+
+# create link to file
+ln myrenamedfile mylink
+ls -lai
+
+# read/write file
+echo "message" > myrenamedfile
+cat myrenamedfile
+
+# remove link to file
+rm mylink
+ls -la
+
+# delete file
+rm -f myrenamedfile
+ls -la
+
+# unmount filesystem
+cd ..
+umount /mnt/myfs
+
+# unload module
+rmmod myfs

--- a/tools/labs/skels/filesystems/myfs/test-myfs.sh
+++ b/tools/labs/skels/filesystems/myfs/test-myfs.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -ex
+
+#load module
+insmod myfs.ko
+
+#mount filesystem
+mkdir -p /mnt/myfs
+mount -t myfs none /mnt/myfs
+
+#show registered filesystems
+cat /proc/filesystems | grep myfs
+
+#show mounted filesystems
+cat /proc/mounts | grep myfs
+
+#show filesystem statistics
+stat -f /mnt/myfs
+
+#list all filesystem files
+cd /mnt/myfs
+ls -la
+
+#unmount filesystem
+cd ..
+umount /mnt/myfs
+
+#unload module
+rmmod myfs


### PR DESCRIPTION
# Laborator  8

## myfs
### Exercitiul 1
Structura `file_system_type` a fost initializata pentru sistemul de fisiere virtual `myfs`. In functia de mount specifica acestuia am folosit `mount_nodev` intrucat filesystem-ul este virtual si nu are nevoie de suport fizic. In functiile de init si exit ale modulului am inregistrat/eliminat sistemul de fisiere.

Corectitudinea implementarii am verificat-o prin urmatoarea serie de comenzi in masina virtuala:

```
root@qemux86:~/skels/filesystems/myfs# insmod myfs.ko
myfs: loading out-of-tree module taints kernel.
register_filesystem successful
root@qemux86:~/skels/filesystems/myfs# cat /proc/filesystems | grep myfs
nodev   myfs
root@qemux86:~/skels/filesystems/myfs# mkdir -p /mnt/myfs
root@qemux86:~/skels/filesystems/myfs# mount -t myfs none /mnt/myfs
root inode has 1 link(s)
mount: mounting none on /mnt/myfs failed: Not a directory

```

### Exercitiul 2
In structura de tipul `super_operations` am definit functiile superblock-ului utilizandu-le pe cele generice `generic_delete_inode()` si `simple_statfs()` pentru o functionalitate minimala. Dupa aceea am completat functia `fill_super` completand restul campurilor din superblock.

### Exercitiul 3
Completand functia `myfs_get_inode` am initializat inode-ul radacina. Prelunad informatiile din namespace-ul root am completat campurile `uid`, `gid` si `mode` ale inode-ului. Fiind un director, am adaugat operatiile specifice si am incrementat numarul de link-uri.

### Exercitiul 4
Corectitudinea rezolvarii se poate observa din outputul urmator:

```
root@qemux86:~/skels/filesystems/myfs# mkdir -p /mnt/myfs
root@qemux86:~/skels/filesystems/myfs# mount -t myfs none /mnt/myfs
root inode has 2 link(s)
root@qemux86:~/skels/filesystems/myfs# cat /proc/mounts | grep myfs
none /mnt/myfs myfs rw,relatime 0 0
root@qemux86:~/skels/filesystems/myfs# ls -di /mnt/myfs/
   4282 /mnt/myfs/
root@qemux86:~/skels/filesystems/myfs# stat -f /mnt/myfs
  File: "/mnt/myfs"
    ID: 0        Namelen: 255     Type: UNKNOWN
Block size: 4096
Blocks: Total: 0          Free: 0          Available: 0
Inodes: Total: 0          Free: 0
root@qemux86:~/skels/filesystems/myfs# ls -la /mnt/myfs
drwxr-xr-x    2 root     root             0 Apr 30 12:52 .
drwxr-xr-x    3 root     root          1024 Apr 28 10:36 ..
root@qemux86:~/skels/filesystems/myfs# touch /mnt/myfs/a.txt
touch: /mnt/myfs/a.txt: Permission denied
root@qemux86:~/skels/filesystems/myfs# umount /mnt/myfs
```

## minfs

### Exercitiul 1
In functia de mount `myfs_mount` am folosit `mount_bdev` intrucat filesystem-ul este nu mai este virtual ci are nevoie de suport fizic. Campul `fs_flags` al structurii de tipul `file_system_type` are valoarea `FS_REQUIRES_DEV` pentru a indica un filesystem ce utilizeaza un disk.

Verificam ca filesystem-ul a fost creat cu succes:
```
root@qemux86:~/skels/filesystems/minfs/kernel# cat /proc/filesystems | grep minfs
nodev   minfs
```
## Exercitiul 2
Cu ajutorul functiei `sb_bread` citim block-ul de la index 0, campului `b_data` i se face cast la structura de tip superblock `struct minfs_super_block` (structura custom) si se verifica valoarea magic number-ului. Se copiaza valorile obtinute in superblock-ul generic si in structura de tipul `struct minfs_sb_info`.

## Exercitiul 3
Am completat functiile `minfs_alloc_inode` populand campul `vfs_inode` al structurii alocate folosind functia `inode_init_once`. Conform functiei utilizate,initializare se face o singura data, campurile inode-ului fiind **idempotent** (nu se modifica in urma operatiilor). Apoi am completat functia de dezalocare asociata.

## Exercitiul 4
Cu ajutorul functiei `sb_bread` citim block-ul de la index 1, apoi extragem inode-ul de index-ul `ino`. Am completat campurile `uid`, `gid`, `mode` si `size` ale variabilei `inode` (VFS inode). In cazul in care inode-ul este director, atunci se completeaza si campurile `i_op` si `i_fop` si incrementam numarul de link-uri.

Acum inlocuim apelul functiei `myfs_get_inode` cu aceasta functie `minfs_iget`.

## Exercitiul 5
Testam corectitudinea implementarii:

Setup:
```
root@qemux86:~/skels/filesystems/minfs/user# ./mkfs.minfs /dev/vdd
root@qemux86:~/skels/filesystems/minfs/user# cd
root@qemux86:~# cd skels/filesystems/minfs/kernel/
root@qemux86:~/skels/filesystems/minfs/kernel# insmod minfs.ko
minfs: loading out-of-tree module taints kernel.
root@qemux86:~/skels/filesystems/minfs/kernel# mkdir -p /mnt/minfs/
```
```
root@qemux86:~/skels/filesystems/minfs/user# ./test-minfs.sh
+ insmod ../kernel/minfs.ko
+ mkdir -p /mnt/minfs
+ ./mkfs.minfs /dev/vdb
+ mount -t minfs /dev/vdb /mnt/minfs
released superblock resources
mount: mounting /dev/vdb on /mnt/minfs failed: Not a directory
root@qemux86:~/skels/filesystems/minfs/user#
```
